### PR TITLE
[Features #115109857] Fix unnecessary error  displayed in homepage when there are no episodes to display

### DIFF
--- a/resources/views/app/includes/contents/main.blade.php
+++ b/resources/views/app/includes/contents/main.blade.php
@@ -85,6 +85,6 @@
             </p>
         </div>
     @else
-        <h4 class="center-align padcast-page-header" style="margin-bottom:50px;">Opps sorry we have no episodes yet</h4>
+        <h4 class="center-align padcast-page-header" style="margin-bottom:50px;">Oops sorry we have no episodes yet</h4>
     @endif
 </div>

--- a/resources/views/app/includes/contents/main.blade.php
+++ b/resources/views/app/includes/contents/main.blade.php
@@ -83,7 +83,7 @@
             <a href="/episodes" class=" waves-effect waves-light btn">VIEW OLDER EPISODES</a>
         </p>
         @else
-            <h4 class="center-align padcast-page-header" style="margin-bottom:50px;">Opps sorry we have no episodes yet</h4>
+            <h4 class="center-align padcast-page-header" style="margin-bottom:50px;">Oops sorry we have no episodes yet</h4>
         @endif    
     </div>
 </div>


### PR DESCRIPTION
It was observed that Unnecessary error messages do pop up if the home page is visited when there are no episodes on the website. The error messages are shown below:

![screen shot 2016-03-06 at 4 56 27 pm](https://cloud.githubusercontent.com/assets/14159420/13555337/5dc0c31c-e3be-11e5-8553-866e36be6f0a.png)

After fixing, the image below shows how it looks:

![screen shot 2016-03-06 at 5 07 34 pm](https://cloud.githubusercontent.com/assets/14159420/13555358/e308835c-e3be-11e5-98d1-4488ad66b50e.png)
