### PR TITLE
#115751349 Clean up code in the favorites page

### DIFF
--- a/public/js/like.js
+++ b/public/js/like.js
@@ -35,9 +35,13 @@ $(document).ready(function() {
 
 			$(this).text(" " + like_count);
 			$("#favorite").html(favoriteCount);
+
+			if (window.location.pathname) {
+				location.reload();
+			}
 		}
 
-		if (status === "must_login") 
+		if (status === "must_login")
 		{
 			window.location = "/login";
 		}
@@ -48,7 +52,7 @@ $(document).ready(function() {
 	# Like Episode Function
 	*/
 	function likeEpisode()
-	{	
+	{
 		var url 			= "/episode/like";
 		var token 			= document.getElementById("token").value;
 		var method 			= "POST";

--- a/resources/views/app/includes/contents/favorites.blade.php
+++ b/resources/views/app/includes/contents/favorites.blade.php
@@ -8,21 +8,27 @@
     <div class="col s12 m8 l9">
         @forelse($userEpisodes as $episodes)
         <!-- start card -->
-        <a style="color:#2C3E50" href="/episodes/{{$episodes->id}}">
-            <div class="row podcast">
-                <div class="col s3">
-                    <img class="responsive-img podcast-img" src="{{ asset($episodes->image) }}">
+        <div class="row podcast">
+            <div class="col s3">
+                <a style="color:#2C3E50" href="/episodes/{{$episodes->id}}">
+                    <img class="responsive-img podcast-img" src="{!! asset($episodes->image) !!}">
+                </a>
+            </div>
+
+            <div class="col s9 details">
+                <span class="podcast-episode-date">{{$episodes->created_at->diffForHumans()}}</span>
+                <span class="tag podcast-episode-date">{{$episodes->channel->channel_name}}</span>
+                <a style="color:#2C3E50" href="/episodes/{{$episodes->id}}">
+                    <h5 class="podcast-episode-title">{{$episodes->episode_name}}</h5>
+                </a>
+                <div>
+                    <audio width="10px;" src="{{$episodes->audio_mp3}}" preload="auto" />
                 </div>
+                <p>
+                     {{$episodes->episode_description}}
+                </p>
 
-                <div class="col s9 details">
-                    <span class="podcast-episode-date">{{ $episodes->created_at->diffForHumans() }}</span>
-                    <span class="tag podcast-episode-date">{{$episodes->channel->channel_name}}</span>
-                    <h5 class="podcast-episode-title">{{ $episodes->episode_name }}</h5>
-
-                    <p>
-                        {{$episodes->episode_description}}
-                    </p>
-                     <div class="podcast-actions">
+                <div class="podcast-actions">
 
                     <input type="hidden" id="token" name="_token" value="{{ csrf_token() }}">
 
@@ -33,7 +39,7 @@
                     <input type="hidden" id="episode_id" value="{{ $episodes->id }}">
 
                     <span style="padding-right:15px;">
-                         <i class="fa fa-heart social-btn like-btn dislike"> {{ $episodes->likes }}</i>
+                         <i class="fa fa-heart social-btn like-btn dislike" like-status="dislike"> {{ $episodes->likes }}</i>
                     </span>
 
                     <span style="padding-right:15px;">
@@ -47,10 +53,8 @@
                         </a>
                     </span>
                 </div>
-
-                </div>
             </div>
-        </a>
+        </div>
         <!-- end card -->
 
         @empty

--- a/resources/views/app/includes/contents/favorites.blade.php
+++ b/resources/views/app/includes/contents/favorites.blade.php
@@ -30,19 +30,19 @@
                         <input type="hidden" id="user_id" value="{{ Auth::user()->id }}" >
                     @endif
 
-                    <input type="hidden" id="episode_id" value="{{ $episodes->first()->id }}">
+                    <input type="hidden" id="episode_id" value="{{ $episodes->id }}">
 
                     <span style="padding-right:15px;">
-                         <i class="fa fa-heart social-btn like-btn {{ $episodes->first()->like_status }}" like-status="{{ $episodes->first()->like_status }}"> {{ $episodes->likes }}</i>
+                         <i class="fa fa-heart social-btn like-btn dislike"> {{ $episodes->likes }}</i>
                     </span>
 
                     <span style="padding-right:15px;">
-                        <a href="#" class="twtr-share" data-desc="{{ $episodes->first()->episode_description }}" data-name="{{ $episodes->first()->episode_name }}" data-img="{!! asset($episodes->first()->image) !!}" data-url="{!! url('/episodes', $episodes->first()->id)  !!}">
+                        <a href="#" class="twtr-share" data-desc="{{ $episodes->episode_description }}" data-name="{{ $episodes->episode_name }}" data-img="{!! asset($episodes->image) !!}" data-url="{!! url('/episodes', $episodes->id)  !!}">
                             <i class="fa fa-twitter social-btn "></i>
                         </a>
                     </span>
                     <span style="padding-right:15px;">
-                        <a href="#" class="fb-share" data-desc="{{ $episodes->first()->episode_description }}" data-name="{{ $episodes->first()->episode_name }}" data-img="{!! asset($episodes->first()->image) !!}" data-url="{!! url('/episodes', $episodes->first()->id) !!}">
+                        <a href="#" class="fb-share" data-desc="{{ $episodes->episode_description }}" data-name="{{ $episodes->episode_name }}" data-img="{!! asset($episodes->image) !!}" data-url="{!! url('/episodes', $episodes->id) !!}">
                             <i class="fa fa-facebook social-btn "></i>
                         </a>
                     </span>

--- a/resources/views/app/includes/contents/main.blade.php
+++ b/resources/views/app/includes/contents/main.blade.php
@@ -8,9 +8,9 @@
     @if($episodes->count() > 0)
     <div class="col s12 m8 l9">
 
-        <h4 class="center-align padcast-page-header" style="margin-bottom:50px;">Podcast for Suya lovers</h1>
+        <h4 class="center-align padcast-page-header" style="margin-bottom:50px;">Podcast for Suya lovers</h4>
 
-       <div class="row podcast">
+        <div class="row podcast">
             <div class="col s3">
                 <a style="color:#2C3E50" href="/episodes/{{$episodes->first()->id}}">
                     <img class="responsive-img podcast-img" src="{!! asset($episodes->first()->image) !!}">


### PR DESCRIPTION
#### What does this PR do?
- Makes it possible for users to unfavorite episodes from the favorites page
- Makes the heart icon for the favorited episodes green in color
#### Description of Task to be completed?
- Eliminate all instances where the first episode from the collection of favorited episodes is used as the reference episode
- Make sure one can unfavorite an episode from the favorites page
- Change the styling of the love heart to color green for episodes in the favorites page
#### How should this be manually tested?
- Visit the favorites page
- Unfavorite an episode
- The episode you just unfavorited won't be displayed when the page reloads
#### What are the relevant pivotal tracker stories?
#115751349

[@unicodeveloper](https://github.com/unicodeveloper)
