### PR TITLE
[#115755657] A channel that has no episode should have an appropriate message to display to users.

### DIFF
--- a/resources/views/app/includes/contents/episode.blade.php
+++ b/resources/views/app/includes/contents/episode.blade.php
@@ -8,26 +8,40 @@
 
         <h4 class="center-align padcast-page-header" style="margin-bottom:50px;">Podcast for Suya lovers</h1>
 
-        @foreach($episodes as $podcast)
-        <a style="color:#2C3E50" href="/episodes/{{$podcast->id}}">
-            <div class="row podcast">
-                <div class="col s3">
-                    <img class="responsive-img podcast-img" src="{{ asset($podcast->image) }}">
+        @if ($episodes->count() > 0)
+            @foreach($episodes as $podcast)
+            <a style="color:#2C3E50" href="/episodes/{{$podcast->id}}">
+                <div class="row podcast">
+                    <div class="col s3">
+                        <img class="responsive-img podcast-img" src="{{ asset($podcast->image) }}">
+                    </div>
+
+                    <div class="col s9 details">
+                        <span class="podcast-episode-date">{{ $podcast->created_at->diffForHumans() }}</span>
+                        <span class="tag podcast-episode-date">{{$podcast->channel->channel_name}}</span>
+                        <h5 class="podcast-episode-title">{{ $podcast->episode_name }}</h5>
+
+                        <p>
+                            {{$podcast->episode_description}}
+                        </p>
+
+                    </div>
                 </div>
-
-                <div class="col s9 details">
-                    <span class="podcast-episode-date">{{ $podcast->created_at->diffForHumans() }}</span>
-                    <span class="tag podcast-episode-date">{{$podcast->channel->channel_name}}</span>
-                    <h5 class="podcast-episode-title">{{ $podcast->episode_name }}</h5>
-
-                    <p>
-                        {{$podcast->episode_description}}
-                    </p>
-
+            </a>
+            @endforeach
+        @else
+            <div class="col s12">
+                <div class="card-panel grey lighten-5 z-depth-1">
+                  <div class="row valign-wrapper">
+                    <div class="col s12">
+                      <h4 class="black-text center">
+                        <i class="fa fa-info-circle teal-text"></i> Ooops, there are no episodes in this channel
+                      </h4>
+                    </div>
+                  </div>
                 </div>
-            </div>
-        </a>
-        @endforeach
+              </div>
+        @endif
 
         <p class="center-align">
             <a href="/" class=" waves-effect waves-light btn">Back home</a>

--- a/resources/views/app/includes/contents/episodes.blade.php
+++ b/resources/views/app/includes/contents/episodes.blade.php
@@ -75,7 +75,7 @@
                             </div>
                             <div class="collapsible-body">
                                 <ul class="collection">
-                                
+
                                 <li class="load_comment{{ $episode->id }}">
                                 @foreach ( $episode->comment as $comment  )
                                     <div id="show_comment" class="collection-item avatar show_comment{{ $comment->episode_id }}">
@@ -93,7 +93,7 @@
                                     </div>
                                 @endforeach
                                 </li>
-                                
+
                                 @if (  Auth::check() )
                                     <li class="collection-item avatar">
                                         <div class="row">

--- a/resources/views/dashboard/includes/contents/view_channel.blade.php
+++ b/resources/views/dashboard/includes/contents/view_channel.blade.php
@@ -36,7 +36,7 @@
 
             </tbody>
         </table>
-         @if ($channel->count == 0)
+         @if ($episodes->count() == 0)
 
             <div class="col s12">
                 <div class="card-panel grey lighten-5 z-depth-1">

--- a/resources/views/dashboard/includes/contents/view_channel.blade.php
+++ b/resources/views/dashboard/includes/contents/view_channel.blade.php
@@ -27,12 +27,28 @@
                 </tr>
             </thead>
             <tbody>
+
             @foreach($episodes as $episode)
                 <tr>
                     <td>{{ $episode->episode_name }}</td>
                 </tr>
             @endforeach
+
             </tbody>
         </table>
+         @if ($channel->count == 0)
+
+            <div class="col s12">
+                <div class="card-panel grey lighten-5 z-depth-1">
+                  <div class="row valign-wrapper">
+                    <div class="col s12">
+                      <h4 class="black-text center">
+                        <i class="fa fa-info-circle teal-text"></i> Ooops, there are no episodes in this channel
+                      </h4>
+                    </div>
+                  </div>
+                </div>
+              </div>
+        @endif
     </div>
 </div>

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -186,6 +186,37 @@ class ChannelTest extends TestCase
     }
 
     /**
+     * Test that an admin sees a no episodes message when
+     * a channel is empty
+     *
+     * @return void
+     */
+    public function testAdminGetsMessageOnEmptyChannels()
+    {
+        $admin = factory(User::class)->create(['role_id' => 3]);
+        $channel = factory(Channel::class)->create();
+        $this->actingAs($admin)
+             ->visit('/dashboard/channel/'. $channel['id'])
+             ->see('Ooops, there are no episodes in this channel');
+    }
+
+    /**
+     * Test that a User sees a no episodes message when
+     * a channel is empty
+     *
+     * @return void
+     */
+    public function testUserGetsMessageOnEmptyChannels()
+    {
+        $admin = factory(User::class)->create(['role_id' => 3]);
+        $user = factory(User::class)->create();
+        $channel = factory(Channel::class)->create();
+        $this->actingAs($user)
+             ->visit('/channel/' . $channel['id'])
+             ->see('Ooops, there are no episodes in this channel');
+    }
+
+    /**
      * Test user channnel relationship
      */
     public function testUserChannelRelationship()


### PR DESCRIPTION
#### What does this PR do?

Displays an error message when you visit a channel that has no episodes.
#### Description of Task to be completed?

An admin gets a `no episodes in this channel` message when they visit `GET dashbooard/channel{id}`
A user get a `no episodes in this channel` message when they visit `GET channel/{id}`
#### How should this be manually tested?
1. As an administrator, create a  new channel, visit `GET dashboard/channel{id}` and asserts that they get back a `no episodes in this channel` message 
2. As a user, visit `GET channel{id}` and asserts that they get back a `no episodes in this channel` message 
#### Any background context you want to provide?

Before this fix, the user just got a blank page without message on reason why.
#### What are the relevant pivotal tracker stories?
#115755657
#### Screenshots (if appropriate)

<img width="1440" alt="screen shot 2016-03-16 at 12 35 13" src="https://cloud.githubusercontent.com/assets/16223627/13808095/669914da-eb75-11e5-8403-d6faa46639a6.png">
<img width="1440" alt="screen shot 2016-03-16 at 12 35 06" src="https://cloud.githubusercontent.com/assets/16223627/13808096/66adb052-eb75-11e5-907e-7b03989eb3de.png">

[@unicodeveloper](https://github.com/unicodeveloper)
