### PR TITLE
bg-page-reloads-116055233

### DIFF
--- a/public/js/like.js
+++ b/public/js/like.js
@@ -36,7 +36,8 @@ $(document).ready(function() {
 			$(this).text(" " + like_count);
 			$("#favorite").html(favoriteCount);
 
-			if (window.location.pathname) {
+			//check if the string favorites is present in the current url
+			if (/favorites/.test(window.location.pathname)) {
 				location.reload();
 			}
 		}


### PR DESCRIPTION
#### What does this PR do?
- Prevents the page from reloading when one unfavorites an episode. The reload should only happen if you are on the favorites page
#### Description of Task to be completed?
- Check url of the current pagel
-  If the url has favorites in it reload the page after unfavoriting an episode
#### How should this be manually tested?
- Visit the homepage and unfavorite an episode
- Visit the favorites page and unfavorite an episode
- You will notice the homepage won't reload but the favorites page will reload
#### What are the relevant pivotal tracker stories?
#116055233
