### PR TITLE
116081001 A user can not update a username to nothing.

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -33,6 +33,10 @@ class ProfileController extends Controller
      */
     public function updateProfileSettings(Request $request)
     {
+        $this->validate($request, [
+            'username' => 'required|max:255|unique:users,username,'. Auth::user()->id,
+        ]);
+
         $updateUser = User::where('id', Auth::user()->id)->update(['username' => $request->username]);
 
         return redirect('/profile/edit')->with('status', 'You have successfully updated your profile.');

--- a/tests/UsersTest.php
+++ b/tests/UsersTest.php
@@ -165,4 +165,18 @@ class UsersTest extends TestCase
         $offlineUsers = self::$userRepository->getOfflineUsers();
         $this->assertEquals(3, $offlineUsers->count());
     }
+
+    /**
+     * Assert that a user can update their username
+     *
+     * @return void
+     */
+    public function testUserCanUpdateUserName()
+    {
+        $this->login();
+        $this->visit('profile/edit')
+            ->type('foobar', 'username')
+            ->press('update');
+        $this->seeInDatabase('users', ['id' => 1, 'username' => 'foobar']);
+    }
 }


### PR DESCRIPTION
#### What does this PR do?

Fix bug: A user can not update a username to be empty
#### Description of Task to be completed?

currently, a user can enter empty string as username and update. 
The consequence of this is once the user's session expires, the user will never be able to sign in to that account again because username field has been set to empty.
 You should address this in your update user profile code.
#### How should this be manually tested?
1. create account
2. go to `/profile/edit`
3. Try to update the username to nothing
4. Update the username to a valid value
#### What are the relevant pivotal tracker stories?

[#11608100]
#### Screenshots (if appropriate)

<img width="997" alt="screen shot 2016-03-22 at 11 11 35" src="https://cloud.githubusercontent.com/assets/16223627/13945510/f54a1384-f01e-11e5-932f-850296b008cb.png">

[@unicodeveloper](https://github.com/unicodeveloper)
