### PR TITLE
#116055233 Remove only unfavorited episode after the page reloads

### DIFF
--- a/public/js/like.js
+++ b/public/js/like.js
@@ -5,7 +5,7 @@ $(document).ready(function() {
 
         var this_ = $(this);
         var status        = $(this).attr("like-status");
-        var like_count    = $(this).html();
+        var likeCount    = $(this).html();
         var favoriteCount = $("#favorite").html();
 
         if (status === "like")
@@ -14,12 +14,12 @@ $(document).ready(function() {
             $(this).addClass("dislike");
             $(this).attr("like-status", "dislike");
 
-            likeEpisode()
+            likeEpisode();
 
-            like_count = Number(like_count) + 1;
+            likeCount = Number(likeCount) + 1;
             favoriteCount = Number(favoriteCount) + 1;
 
-            $(this).text( " " + like_count);
+            $(this).text( " " + likeCount);
             $("#favorite").html(favoriteCount);
         }
 
@@ -29,12 +29,12 @@ $(document).ready(function() {
             $(this).addClass("like");
             $(this).attr("like-status", "like");
 
-            dislikeEpisode(this_)
+            dislikeEpisode(this_);
 
-            like_count = Number(like_count) - 1;
+            likeCount = Number(likeCount) - 1;
             favoriteCount = Number(favoriteCount) - 1;
 
-            $(this).text(" " + like_count);
+            $(this).text(" " + likeCount);
             $("#favorite").html(favoriteCount);
 
             //check if the string favorites is present in the current url
@@ -48,7 +48,7 @@ $(document).ready(function() {
             window.location = "/login";
         }
 
-    })
+    });
 
     /*
     # Like Episode Function
@@ -69,9 +69,9 @@ $(document).ready(function() {
               user_id       : document.getElementById("user_id").value,
               episode_id    : document.getElementById("episode_id").value
             }
-        }
+        };
 
-        ajaxCall(data)
+        ajaxCall(data);
     }
 
     /*
@@ -93,9 +93,9 @@ $(document).ready(function() {
               user_id       : document.getElementById("user_id").value,
               episode_id    : this_.attr("data-episode-id")
             }
-        }
+        };
 
-        ajaxCall(data)
+        ajaxCall(data);
     }
 
     /*
@@ -107,7 +107,7 @@ $(document).ready(function() {
             url     : data.url,
             type    : data.method,
             data    : data.parameter,
-            success: function (response)
+            success: function ()
             {
             },
             error: function()

--- a/public/js/like.js
+++ b/public/js/like.js
@@ -1,118 +1,119 @@
 
 $(document).ready(function() {
 
-	$(".like-btn").click(function () {
+    $(".like-btn").click(function () {
 
-		var status 		  = $(this).attr("like-status");
-		var like_count	  = $(this).html();
-		var favoriteCount = $("#favorite").html();
+        var this_ = $(this);
+        var status        = $(this).attr("like-status");
+        var like_count    = $(this).html();
+        var favoriteCount = $("#favorite").html();
 
-		if (status === "like")
-		{
-			$(this).removeClass("like");
-			$(this).addClass("dislike");
-			$(this).attr("like-status", "dislike");
+        if (status === "like")
+        {
+            $(this).removeClass("like");
+            $(this).addClass("dislike");
+            $(this).attr("like-status", "dislike");
 
-			likeEpisode()
+            likeEpisode()
 
-			like_count = Number(like_count) + 1;
-			favoriteCount = Number(favoriteCount) + 1;
+            like_count = Number(like_count) + 1;
+            favoriteCount = Number(favoriteCount) + 1;
 
-			$(this).text( " " + like_count);
-			$("#favorite").html(favoriteCount);
-		}
+            $(this).text( " " + like_count);
+            $("#favorite").html(favoriteCount);
+        }
 
-		if (status === "dislike")
-		{
-			$(this).removeClass("dislike");
-			$(this).addClass("like");
-			$(this).attr("like-status", "like");
+        if (status === "dislike")
+        {
+            $(this).removeClass("dislike");
+            $(this).addClass("like");
+            $(this).attr("like-status", "like");
 
-			dislikeEpisode()
+            dislikeEpisode(this_)
 
-			like_count = Number(like_count) - 1;
-			favoriteCount = Number(favoriteCount) - 1;
+            like_count = Number(like_count) - 1;
+            favoriteCount = Number(favoriteCount) - 1;
 
-			$(this).text(" " + like_count);
-			$("#favorite").html(favoriteCount);
+            $(this).text(" " + like_count);
+            $("#favorite").html(favoriteCount);
 
-			//check if the string favorites is present in the current url
-			if (/favorites/.test(window.location.pathname)) {
-				location.reload();
-			}
-		}
+            //check if the string favorites is present in the current url
+            if (/favorites/.test(window.location.pathname)) {
+                location.reload();
+            }
+        }
 
-		if (status === "must_login")
-		{
-			window.location = "/login";
-		}
+        if (status === "must_login")
+        {
+            window.location = "/login";
+        }
 
-	})
+    })
 
-	/*
-	# Like Episode Function
-	*/
-	function likeEpisode()
-	{
-		var url 			= "/episode/like";
-		var token 			= document.getElementById("token").value;
-		var method 			= "POST";
+    /*
+    # Like Episode Function
+    */
+    function likeEpisode()
+    {
+        var url             = "/episode/like";
+        var token           = document.getElementById("token").value;
+        var method          = "POST";
 
-	  	var data =
-	    {
-	        url         	: url,
-	        method 			: method,
-	        parameter   	:
-	        {
-	          _token		: token,
-	          user_id		: document.getElementById("user_id").value,
-	          episode_id	: document.getElementById("episode_id").value
-	        }
-	    }
+        var data =
+        {
+            url             : url,
+            method          : method,
+            parameter       :
+            {
+              _token        : token,
+              user_id       : document.getElementById("user_id").value,
+              episode_id    : document.getElementById("episode_id").value
+            }
+        }
 
-		ajaxCall(data)
-	}
+        ajaxCall(data)
+    }
 
-	/*
-	# Dislike Episode Function
-	*/
-	function dislikeEpisode()
-	{
-		var url 			= "/episode/unlike";
-		var token 			= document.getElementById("token").value;
-		var method 			= "post";
+    /*
+    # Dislike Episode Function
+    */
+    function dislikeEpisode(this_)
+    {
+        var url             = "/episode/unlike";
+        var token           = document.getElementById("token").value;
+        var method          = "post";
 
-	  	var data =
-	    {
-	        url         	: url,
-	        method 			: method,
-	        parameter   	:
-	        {
-	          _token		: token,
-	          user_id		: document.getElementById("user_id").value,
-	          episode_id	: document.getElementById("episode_id").value
-	        }
-	    }
+        var data =
+        {
+            url             : url,
+            method          : method,
+            parameter       :
+            {
+              _token        : token,
+              user_id       : document.getElementById("user_id").value,
+              episode_id    : this_.attr("data-episode-id")
+            }
+        }
 
-		ajaxCall(data)
-	}
+        ajaxCall(data)
+    }
 
-	/*
-	# Ajax
-	*/
-	function ajaxCall(data)
-	{
-		$.ajax({
-			url		: data.url,
-			type	: data.method,
-			data	: data.parameter,
-			success: function (response)
-			{
-			},
-			error: function()
-			{
-				alert("Are you sure you doing this the right way?");
-			},
-		});
-	}
+    /*
+    # Ajax
+    */
+    function ajaxCall(data)
+    {
+        $.ajax({
+            url     : data.url,
+            type    : data.method,
+            data    : data.parameter,
+            success: function (response)
+            {
+            },
+            error: function()
+            {
+                alert("Are you sure you doing this the right way?");
+            },
+        });
+    }
 })

--- a/resources/views/app/includes/contents/favorites.blade.php
+++ b/resources/views/app/includes/contents/favorites.blade.php
@@ -39,7 +39,7 @@
                     <input type="hidden" id="episode_id" value="{{ $episodes->id }}">
 
                     <span style="padding-right:15px;">
-                         <i class="fa fa-heart social-btn like-btn dislike" like-status="dislike"> {{ $episodes->likes }}</i>
+                         <i class="fa fa-heart social-btn like-btn dislike" like-status="dislike" data-episode-id="{{ $episodes->id }}"> {{ $episodes->likes }}</i>
                     </span>
 
                     <span style="padding-right:15px;">

--- a/resources/views/app/includes/contents/main.blade.php
+++ b/resources/views/app/includes/contents/main.blade.php
@@ -41,7 +41,7 @@
                     <input type="hidden" id="episode_id" value="{{ $episodes->first()->id }}">
 
                     <span style="padding-right:15px;">
-                         <i class="fa fa-heart social-btn like-btn {{ $episodes->first()->like_status }}" like-status="{{ $episodes->first()->like_status }}"> {{ $episodes->first()->likes }}</i>
+                         <i class="fa fa-heart social-btn like-btn {{ $episodes->first()->like_status }}" like-status="{{ $episodes->first()->like_status }}" data-episode-id="{{ $episodes->first()->id }}"> {{ $episodes->first()->likes }}</i>
                     </span>
 
                     <span style="padding-right:15px;">

--- a/resources/views/app/includes/contents/single_episode.blade.php
+++ b/resources/views/app/includes/contents/single_episode.blade.php
@@ -6,7 +6,7 @@
 
     <!-- Feeds Area -->
     <div class="col s12 m8 l9">
-           
+
         <h4 class="center-align padcast-page-header" style="margin-bottom:50px;">Podcast for Suya lovers</h4>
 
         <div class="row podcast">
@@ -18,41 +18,41 @@
                 <span class="podcast-episode-date">{{ $episodes->first()->created_at->diffForHumans() }}</span>
                 <span class="tag podcast-episode-date">{{ $episodes->first()->channel->channel_name }}</span>
                 <h5 class="podcast-episode-title">{{ $episodes->first()->episode_name }}</h5>
-                
+
                 <div>
                     <audio width="10px;" src="{{ $episodes->first()->audio_mp3 }}" preload="auto" />
                 </div>
-                
+
                 <p>
                     {{ $episodes->first()->episode_description }}
                 </p>
-         
+
                 <div class="podcast-actions">
 
                     <input type="hidden" id="token" name="_token" value="{{ csrf_token() }}">
-                    
+
                     @if( Auth::check() )
                         <input type="hidden" id="user_id" value="{{ Auth::user()->id }}" >
-                    @endif         
+                    @endif
 
                     <input type="hidden" id="episode_id" value="{{ $episodes->first()->id }}">
-                    
+
                     <span style="padding-right:15px;">
-                         <i class="fa fa-heart social-btn like-btn {{ $episodes->first()->like_status }}" like-status="{{ $episodes->first()->like_status }}"> {{ $episodes->first()->likes }}</i>
+                         <i class="fa fa-heart social-btn like-btn {{ $episodes->first()->like_status }}" like-status="{{ $episodes->first()->like_status }}" data-episode-id="{{ $episodes->first()->id }}"> {{ $episodes->first()->likes }}</i>
                     </span>
 
                     <span style="padding-right:15px;">
                         <a href="#" class="twtr-share" data-desc="{{ $episodes->first()->episode_description }}" data-name="{{ $episodes->first()->episode_name }}" data-img="{!! asset($episodes->first()->image) !!}" data-url="{!! url('/episodes', $episodes->first()->id)  !!}">
                             <i class="fa fa-twitter social-btn "></i>
                         </a>
-                    </span>                    
+                    </span>
                     <span style="padding-right:15px;">
                         <a href="#" class="fb-share" data-desc="{{ $episodes->first()->episode_description }}" data-name="{{ $episodes->first()->episode_name }}" data-img="{!! asset($episodes->first()->image) !!}" data-url="{!! url('/episodes', $episodes->first()->id) !!}">
                             <i class="fa fa-facebook social-btn "></i>
                         </a>
-                    </span>            
+                    </span>
                 </div>
-         
+
             </div>
 
             <div class="col s12 m6 l12 card-social">
@@ -84,7 +84,7 @@
 
                                                             @if ( Auth::user()->id === $comment->user_id )
                                                             <div class="update-actions pull-right">
-                                                                <a href="#" id="comment_action_caret" class="fa fa-bars no-style-link"></a> 
+                                                                <a href="#" id="comment_action_caret" class="fa fa-bars no-style-link"></a>
                                                                 <div id="comment_actions" style="display:none">
                                                                     <a href="#" class="fa fa-pencil comment-action-edit no-style-link" data-commentId="{{ $comment->comment_id }}"></a>
                                                                     <a href="#" class="fa fa-trash comment-action-delete no-style-link" data-commentId="{{ $comment->id }}"></a>


### PR DESCRIPTION
#### What does this PR do?
- Fixes the issue where after unfavoriting an episode in the favorites page, the first episode in the list is unfavorited instead and removed from the list.
- This should not be the case since we should only remove the episode that was unfavorited.
#### Description of Task to be completed?
- Create an episode-id attribute in the heart icon.
- Grab an episode using this `episode-id` when one unfavorites an episode
- Remove the episode from the favorites list
#### How should this be manually tested?
- Favorite a couple of episodes from the homepage
- Visit the  favorites page
- Unfavorite any episode
- You will notice that a page reload will happen and the episode you unfavorited won't be present
#### What are the relevant pivotal tracker stories?
#116121723
