### PR TITLE
#116125067 Validate admin channel title and description before creating or updating

### DIFF
--- a/app/Http/Controllers/ChannelController.php
+++ b/app/Http/Controllers/ChannelController.php
@@ -70,30 +70,19 @@ class ChannelController extends Controller
      */
     public function processCreate(Request $request)
     {
-        try {
-            $channel = Channel::create([
-                'channel_name'         => $request->name,
-                'channel_description'  => $request->description,
-                'user_id'              => Auth::user()->id,
-                'subscription_count'   => 0
-            ]);
+        $this->validate($request, [
+            'channel_name' => 'required|max:255|unique:channels',
+            'channel_description' => 'required',
+        ]);
 
-            $this->response =
-            [
-                'message'       => 'Channel created Successfully',
-                'status_code'   => 200
-            ];
+        $channel = Channel::create([
+            'channel_name'         => $request->channel_name,
+            'channel_description'  => $request->channel_description,
+            'user_id'              => Auth::user()->id,
+            'subscription_count'   => 0
+        ]);
 
-        } catch (QueryException $e) {
-
-            $this->response =
-            [
-                'message'       => 'Channel already exist',
-                'status_code'   => 400
-            ];
-        }
-
-        return $this->response;
+        return redirect('dashboard/channel/' . $channel->id);
     }
 
     /**
@@ -193,14 +182,14 @@ class ChannelController extends Controller
     {
         $channel = Channel::find($id);
         $episodes = Episode::where('channel_id', '=', $id)->get();
-        
+
         return view('dashboard.pages.view_channel')->with('channel', $channel)->with('episodes', $episodes);
     }
 
     /**
      * return view to swap episodes to another channel
      * @param int $id
-     * @return 
+     * @return
      */
     public function swap($id)
     {
@@ -214,8 +203,8 @@ class ChannelController extends Controller
      * move episodes from source to destination
      * @param  [type] $id [description]
      * @return [type]     [description]
-     */ 
-    
+     */
+
     public function processSwap(Request $request)
     {
         try {

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -46,17 +46,14 @@ $(document).ready(function(){
      * onSubmit swap channels
      */
     $("#swap_episodes").submit( function () {
-        var id      = $("#channel_id").val();
         var url     = "/dashboard/channel/swap/"+id;
-        var new_channel_id = $("#new_channel_id").val();
-        var token   = $("#token").val();
         var data    =
             {
                 parameter  :
                 {
-                    _token        : token,
-                    channel_id              : id,
-                    new_channel_id          : new_channel_id
+                    _token        : $("#token").val(),
+                    channel_id              : $("#channel_id").val(),
+                    new_channel_id          : $("#new_channel_id").val()
                 }
             }
 
@@ -72,10 +69,10 @@ $(document).ready(function(){
 
         event.preventDefault();
 
-        var channel_name = $("#channel_name").val().trim();
-        var channel_description = $("#channel_description").val().trim();
+        var channelName = $("#channel_name").val().trim();
+        var channelDescription = $("#channel_description").val().trim();
 
-        if( channel_name.length != 0 && channel_description.length ) {
+        if( channelName.length != 0 && channelDescription.length ) {
 
             var data =
             {
@@ -84,8 +81,8 @@ $(document).ready(function(){
                 {
                     _token                : $("#token").val(),
                     channel_id            : $("#channel_id").val(),
-                    channel_name          : channel_name,
-                    channel_description   : channel_description
+                    channel_name          : channelName,
+                    channel_description   : channelDescription
                 }
             }
             processAjax("PUT", data.url, data.parameter, data.parameter.channel_name );
@@ -107,23 +104,17 @@ $(document).ready(function(){
      * onSubmit event to handle Channel update
      */
     $("#episode_update").submit( function () {
-        var url                 = "/dashboard/episode/edit";
-        var token               = $("#token").val();
-        var episode_id          = $("#episode_id").val();
-        var episode             = $("#episode").val();
-        var channel_id          = $("#channel_id").val();
-        var description         = $("#description").val();
 
         var data =
         {
-            url        : url,
+            url        : "/dashboard/episode/edit",
             parameter  :
             {
-                _token                : token,
-                episode_id            : episode_id,
-                episode               : episode,
-                channel_id            : channel_id,
-                description           : description
+                _token                : $("#token").val(),
+                episode_id            : $("#episode_id").val(),
+                episode               : $("#episode").val(),
+                channel_id            : $("#channel_id").val(),
+                description           : $("#description").val()
             }
         }
 
@@ -142,7 +133,7 @@ $(document).ready(function(){
         var url       = "/dashboard/user/create";
         var token     = $("#_token").val();
         var username  = $("#username").val();
-        var user_role = $("#user_role").val();
+        var userRole = $("#user_role").val();
         var data =
             {
                 url        : url,
@@ -150,7 +141,7 @@ $(document).ready(function(){
                 {
                     _token      : token,
                     username    : username,
-                    user_role   : user_role
+                    user_role   : userRole
                 }
             }
         processAjax("POST", data.url, data.parameter, data.parameter.username );
@@ -162,20 +153,15 @@ $(document).ready(function(){
      * onSubmit event to handle User Edit
      */
     $("#edit_user").submit( function () {
-        var url       = "/dashboard/user/edit";
-        var token     = $("#_token").val();
-        var user_id   = $("#user_id").val();
-        var username  = $("#username").val();
-        var user_role = $("#user_role").val();
         var data =
             {
-                url        : url,
+                url        : "/dashboard/user/edit",
                 parameter  :
                 {
-                    _token      : token,
-                    user_id     : user_id,
-                    username    : username,
-                    user_role   : user_role
+                    _token      : $("#_token").val(),
+                    user_id     :  $("#user_id").val(),
+                    username    : $("#username").val(),
+                    user_role   : $("#user_role").val()
                 }
             }
         processAjax("PUT", data.url, data.parameter, data.parameter.username );

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -4,16 +4,12 @@ $(document).ready(function(){
      * onClick event to handle Channel delete
      */
     $("#delete_channel", this).on("click", function () {
-        var id      = $(this).data("id");
-        var url     = "/dashboard/channel/"+id;
-        var token   = $(this).data("token");
-        var name    = $(this).data("name");
         var data    =  {
-            url : url,
+            url : "/dashboard/channel/"+id,
             parameter: {
-                _token       : token,
-                channel_id   : id,
-                channel_name : name
+                _token       : $(this).data("token"),
+                channel_id   : $(this).data("id"),
+                channel_name : $(this).data("name")
             }
         }
         // confirmDelete(data.url, data.parameter, data.parameter.channel_id, data.parameter.channel_name );
@@ -23,18 +19,13 @@ $(document).ready(function(){
     });
 
     $("#swap_episode_delete_channel", this).on("click", function () {
-        var id      = $(this).data("id");
-        var url     = "/dashboard/channel/"+id;
-        var token   = $(this).data("token");
-        var name    = $(this).data("name");
-        var episodes = $(this).data("episoes");
         var data    =  {
-            url : url,
+            url : "/dashboard/channel/"+id,
             parameter: {
-                _token       : token,
-                channel_id   : id,
-                channel_name : name,
-                episodes : episodes
+                _token       : $(this).data("token"),
+                channel_id   : $(this).data("id"),
+                channel_name : $(this).data("name"),
+                episodes : $(this).data("episoes")
             }
         }
         confirmDelete(data.url, data.parameter, data.parameter.channel_id, data.parameter.channel_name );

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -73,9 +73,9 @@ $(document).ready(function(){
         event.preventDefault();
 
         var channel_name = $("#channel_name").val().trim();
-        var channel_description = $("#channel_description").val().trim().;
+        var channel_description = $("#channel_description").val().trim();
 
-        if( channel_name.length != 0 && channel_descriptionlength ) {
+        if( channel_name.length != 0 && channel_description.length ) {
 
             var data =
             {

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -43,29 +43,6 @@ $(document).ready(function(){
     });
 
     /**
-     * onSubmit event to handle Channel creation
-     */
-    $("#create_channel").submit( function () {
-        var url = "/dashboard/channel/create";
-        var token               = $("#token").val();
-        var channel_name        = $("#name").val();
-        var channel_description = $("#description").val();
-        var data =
-            {
-                url        : url,
-                parameter  :
-                {
-                    _token        : token,
-                    name          : channel_name,
-                    description   : channel_description
-                }
-            }
-        processAjax("POST", data.url, data.parameter, data.parameter.channel_name );
-
-        return false;
-    });
-
-    /**
      * onSubmit swap channels
      */
     $("#swap_episodes").submit( function () {
@@ -98,7 +75,7 @@ $(document).ready(function(){
         var channel_name        = $("#channel_name").val();
         var channel_description = $("#channel_description").val();
 
-        var data = 
+        var data =
         {
             url        : url,
             parameter  :
@@ -124,7 +101,7 @@ $(document).ready(function(){
         var episode             = $("#episode").val();
         var channel_id          = $("#channel_id").val();
         var description         = $("#description").val();
-        
+
         var data =
         {
             url        : url,
@@ -139,7 +116,7 @@ $(document).ready(function(){
         }
 
         processEpisodeUpdate("PUT", data.url, data.parameter, data.parameter.episode );
-        
+
         // confirmUpdate(data.url, data.parameter, data.parameter.episode_name, data.parameter.channel_id);
 
 
@@ -224,7 +201,7 @@ function confirmDelete (url, parameter, id, name)
     function ( isConfirm )
     {
         if ( isConfirm) {
-            document.location.href = "/dashboard/channel/swap/"+id;    
+            document.location.href = "/dashboard/channel/swap/"+id;
         } else {
             document.location.href = "/dashboard/channels/all";
         }

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -68,25 +68,37 @@ $(document).ready(function(){
     /**
      * onSubmit event to handle Channel update
      */
-    $("#channel_update").submit( function () {
-        var url                 = "/dashboard/channel/edit";
-        var token               = $("#token").val();
-        var channel_id          = $("#channel_id").val();
-        var channel_name        = $("#channel_name").val();
-        var channel_description = $("#channel_description").val();
+    $("#channel_update").submit( function (event) {
 
-        var data =
-        {
-            url        : url,
-            parameter  :
+        event.preventDefault();
+
+        var channel_name = $("#channel_name").val().trim();
+        var channel_description = $("#channel_description").val().trim().;
+
+        if( channel_name.length != 0 && channel_descriptionlength ) {
+
+            var data =
             {
-                _token                : token,
-                channel_id            : channel_id,
-                channel_name          : channel_name,
-                channel_description   : channel_description
+                url        : "/dashboard/channel/edit",
+                parameter  :
+                {
+                    _token                : $("#token").val(),
+                    channel_id            : $("#channel_id").val(),
+                    channel_name          : channel_name,
+                    channel_description   : channel_description
+                }
             }
+            processAjax("PUT", data.url, data.parameter, data.parameter.channel_name );
+        } else{
+            swal({
+                title: "Error!",
+                text: "Please provide both a channel name and description",
+                type: "error",
+                showCancelButton: false,
+                closeOnConfirm: false,
+                showLoaderOnConfirm: true,
+            });
         }
-        processAjax("PUT", data.url, data.parameter, data.parameter.channel_name );
 
         return false;
     });

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -4,11 +4,13 @@ $(document).ready(function(){
      * onClick event to handle Channel delete
      */
     $("#delete_channel", this).on("click", function () {
+        var id      = $(this).data("id");
+        var url     = "/dashboard/channel/"+id;
         var data    =  {
-            url : "/dashboard/channel/"+id,
+            url : url,
             parameter: {
                 _token       : $(this).data("token"),
-                channel_id   : $(this).data("id"),
+                channel_id   : id,
                 channel_name : $(this).data("name")
             }
         }
@@ -19,11 +21,13 @@ $(document).ready(function(){
     });
 
     $("#swap_episode_delete_channel", this).on("click", function () {
+        var id      = $(this).data("id");
+        var url     = "/dashboard/channel/"+id;
         var data    =  {
-            url : "/dashboard/channel/"+id,
+            url : url,
             parameter: {
                 _token       : $(this).data("token"),
-                channel_id   : $(this).data("id"),
+                channel_id   : id,
                 channel_name : $(this).data("name"),
                 episodes : $(this).data("episoes")
             }

--- a/resources/views/dashboard/includes/contents/create_channel.blade.php
+++ b/resources/views/dashboard/includes/contents/create_channel.blade.php
@@ -2,17 +2,22 @@
     <div class="row">
         <h4>Create Channel</h4><br>
         <div class="row">
+            <div class="col s12 m4 l8">
+                @include('dashboard.includes.sections.alerts')
+            </div>
+        </div>
+        <div class="row">
             <form class="col s12" id="create_channel" action="/dashboard/channel/create" method="post">
                 <input type="hidden" value="{{ csrf_token() }}" name="_token" id="token" />
                 <div class="row">
                     <div class="input-field col s12">
-                        <input placeholder="Channel Title" name="name" id="name" type="text" require="true">
+                        <input placeholder="Channel Title" name="channel_name" id="name" type="text" require="true">
                         <label for="name">Channel Title</label>
                     </div>
                 </div>
                 <div class="row">
                     <div class="input-field col s12">
-                        <input type="text" id="description" name="description" placeholder="Channel Description" require="true">
+                        <input type="text" id="description" name="channel_description" placeholder="Channel Description" require="true">
                         <label for="description">Description</label>
                     </div>
                 </div>

--- a/resources/views/dashboard/includes/contents/edit_channel.blade.php
+++ b/resources/views/dashboard/includes/contents/edit_channel.blade.php
@@ -13,9 +13,7 @@
                 </div>
                 <div class="row">
                     <div class="input-field col s12">
-                        <textarea name="channel_description" class="materialize-textarea" id="channel_description">
-                            {{ $channels->channel_description }}
-                        </textarea>
+                        <textarea name="channel_description" class="materialize-textarea" id="channel_description">{{ $channels->channel_description }}</textarea>
                         <label for="description">Episode Description</label>
                     </div>
                 </div>

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -38,28 +38,28 @@ class ChannelTest extends TestCase
     {
         $user = factory(User::class)->create(['role_id' => 3]);
         $this->actingAs($user)
-         ->visit('/dashboard/channel/create')
-         ->type('Swanky new name', 'channel_name')
-         ->type('Swanky new description', 'channel_description')
-         ->press('create')
-         ->seeInDatabase('channels', [
-            'channel_name' => 'Swanky new name'
-         ]);
+             ->visit('dashboard/channel/create')
+             ->type('Swanky new name', 'channel_name')
+             ->type('Swanky new description', 'channel_description')
+             ->press('create')
+             ->seeInDatabase('channels', [
+                'channel_name' => 'Swanky new name'
+             ]);
 
          $admin = factory(User::class)->create(['role_id' => 3]);
-         $newChannel  = $this->actingAs($admin)
-         ->call(
-             'POST',
-             '/dashboard/channel/create',
-             [
-                'channel_name' => 'Another Channel Name',
-                'channel_description' => 'Another channel description',
-                '_token' => csrf_token()
-             ]
-         );
-         $this->seeInDatabase('channels', [
-            'channel_name' => 'Another Channel Name'
-         ]);
+         $this->actingAs($admin)
+             ->call(
+                 'POST',
+                 '/dashboard/channel/create',
+                 [
+                    'channel_name' => 'Another Channel Name',
+                    'channel_description' => 'Another channel description',
+                    '_token' => csrf_token()
+                 ]
+             );
+             $this->seeInDatabase('channels', [
+                'channel_name' => 'Another Channel Name'
+             ]);
     }
 
     /**

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -36,13 +36,11 @@ class ChannelTest extends TestCase
      */
     public function testCreateChannel()
     {
-        $this->withoutMiddleware();
-
         $user = factory(User::class)->create(['role_id' => 3]);
         $this->actingAs($user)
          ->visit('/dashboard/channel/create')
-         ->type('Swanky new name', 'name')
-         ->type('Swanky new description', 'description')
+         ->type('Swanky new name', 'channel_name')
+         ->type('Swanky new description', 'channel_description')
          ->press('create')
          ->seeInDatabase('channels', [
             'channel_name' => 'Swanky new name'
@@ -54,28 +52,13 @@ class ChannelTest extends TestCase
              'POST',
              '/dashboard/channel/create',
              [
-                'name' => 'Another Channel Name',
-                'description' => 'Another channel description'
+                'channel_name' => 'Another Channel Name',
+                'channel_description' => 'Another channel description',
+                '_token' => csrf_token()
              ]
          );
-
-         $this->assertEquals(200, $newChannel->original['status_code']);
-         $this->assertEquals("Channel created Successfully", $newChannel->original['message']);
-
-         $duplicateChannel  = $this->actingAs($user)
-         ->call(
-             'POST',
-             '/dashboard/channel/create',
-             [
-                'name' => 'Another Channel Name',
-                'description' => 'Another channel description'
-             ]
-         );
-         $this->assertEquals(400, $duplicateChannel->original['status_code']);
-         $this->assertEquals("Channel already exist", $duplicateChannel->original['message']);
-
          $this->seeInDatabase('channels', [
-         'channel_name' => 'Another Channel Name'
+            'channel_name' => 'Another Channel Name'
          ]);
     }
 


### PR DESCRIPTION
#### What does this PR do?

Validate admin channel title and description before creating or updating
#### Description of Task to be completed?

Currently, An admin can create an empty channel without a title and a description.
1. Validate that the title must be required and the user gets a message if they provide an empty title.
2. Validate that the description is required and the user gets a message if the channel description is not provided.

Write tests to assert this validation updates.
#### How should this be manually tested?

**Validate creating a new channel**
1. Create a new administrator
2. Go to the dashboard and click on create on the channel's section.
3. If a user has not provided any name and description, the user will get an error message that the fields have not been provided.
4. If a user tries to create a channel that already exists, the user will get an error message that the channel already exists.
5. If all details have been provided, the user will be redirected to the page of the new channel.

**Validate Updating an existing Channel**
1. While logged in as an admin, go to the dashboard and click on active channels.
2. Click on edit on an episode, delete the description and try to update the channel.
3. The user gets an error message that the name and description are required. 
#### What are the relevant pivotal tracker stories?
#116125067
#### Screenshots

<img width="1440" alt="screen shot 2016-03-23 at 00 58 15" src="https://cloud.githubusercontent.com/assets/16223627/13969197/710e15ba-f092-11e5-8e7b-d6766b83c711.png">
<img width="1440" alt="screen shot 2016-03-23 at 00 58 44" src="https://cloud.githubusercontent.com/assets/16223627/13969201/72d1cda6-f092-11e5-8300-0ebb27b7c1ee.png">

[@unicodeveloper](https://github.com/unicodeveloper)
