### PR TITLE
#116592613 Display Error when one tries to send invite on an empty username

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -127,10 +127,10 @@ $(document).ready(function(){
     $("#create_user").submit( function () {
         var url       = "/dashboard/user/create";
         var token     = $("#_token").val();
-        var username  = $("#username").val();
+        var username  = $("#username").val().trim();
 
         //throw error if nothing was passes in the username field
-        if (username.trim().length === 0) {
+        if (username.length === 0) {
             swal({
                 title: "Error!",
                 text: "Please provide a username",

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -128,6 +128,17 @@ $(document).ready(function(){
         var url       = "/dashboard/user/create";
         var token     = $("#_token").val();
         var username  = $("#username").val();
+        if (username.length == 0) {
+            swal({
+                title: "Error!",
+                text: "Please provide a username",
+                type: "error",
+                showCancelButton: false,
+                closeOnConfirm: true,
+                showLoaderOnConfirm: true,
+            });
+            return false;
+        }
         var userRole = $("#user_role").val();
         var data =
             {

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -128,7 +128,8 @@ $(document).ready(function(){
         var url       = "/dashboard/user/create";
         var token     = $("#_token").val();
         var username  = $("#username").val();
-        if (username.length == 0) {
+        //throw error if nothing was passes in the username field
+        if (username.length === 0) {
             swal({
                 title: "Error!",
                 text: "Please provide a username",

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -130,8 +130,7 @@ $(document).ready(function(){
         var username  = $("#username").val();
 
         //throw error if nothing was passes in the username field
-        username = username.trim();
-        if (username.length === 0) {
+        if (username.trim().length === 0) {
             swal({
                 title: "Error!",
                 text: "Please provide a username",

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -128,7 +128,9 @@ $(document).ready(function(){
         var url       = "/dashboard/user/create";
         var token     = $("#_token").val();
         var username  = $("#username").val();
+
         //throw error if nothing was passes in the username field
+        username = username.trim();
         if (username.length === 0) {
             swal({
                 title: "Error!",


### PR DESCRIPTION
#### What does this PR do?
- Fixes the issue where one could send an invite without passing in a username
#### Description of Task to be completed?
- Check if username is empty when making the post request
- If username is empty display an error using sweet alert that the username cannot be empty
#### How should this be manually tested?
- Login into the admin dashboard (for those with admin privileges)
- Try sending an invite without passing the username
- An error prompt will appear telling you that the username cannot be empty
#### What are the relevant pivotal tracker stories?
#116592613
#### Screenshots (if appropriate)

<img width="811" alt="screen shot 2016-03-30 at 12 49 17 pm" src="https://cloud.githubusercontent.com/assets/8840187/14138445/f888a558-f675-11e5-89fc-358900d341ff.png">
