### PR TITLE
Bg fix create episode 121424627

### DIFF
--- a/app/Http/Controllers/EpisodeManager.php
+++ b/app/Http/Controllers/EpisodeManager.php
@@ -152,8 +152,6 @@ class EpisodeManager extends Controller
     */
     public function store(Request $request)
     {
-        //dd($request->all());
-
         $this->validate($request, [
             'title'         => 'required|min:3',
             'description'   => 'required',

--- a/app/Http/Controllers/EpisodeManager.php
+++ b/app/Http/Controllers/EpisodeManager.php
@@ -152,6 +152,7 @@ class EpisodeManager extends Controller
     */
     public function store(Request $request)
     {
+        //dd($request->all());
 
         $this->validate($request, [
             'title'         => 'required|min:3',
@@ -159,8 +160,6 @@ class EpisodeManager extends Controller
             'channel'       => 'required',
             'podcast'       => 'required|size_format|mimes:mpga'
         ]);
-
-        $file = $request->file('podcast');
 
         $data    = [
             'episode_name'          => $request->title,

--- a/resources/views/dashboard/includes/contents/create_episode.blade.php
+++ b/resources/views/dashboard/includes/contents/create_episode.blade.php
@@ -14,13 +14,14 @@
                     </div>
 
                     <div class="input-field col s6">
-                        <select name="channel">
+                        <select name="channel" style="display:block !important;">
+                            <option value="" name="channel">Select Channel</option>
                             @foreach($channels as $channel)
                                 <option value="{{$channel->id}}" name="channel">{{$channel->channel_name}}
                                 </option>
                             @endforeach
                         </select>
-                        <label for="channel">Channel Name</label>
+                   
                     </div>
                 </div>
 


### PR DESCRIPTION
#### What does this PR do?
- Fix user not being able to successfully create an episode
#### Description of Task to be completed?
- Add style that set the channels select drop down visibility to true.
- Remove unnecessary variable declaration.
- Make sure that channel select drop down is validated
#### How should this be manually tested?
- Authenticated user with either premium or super admin account should visit `https://suyabay-staging.herokuapp.com/dashboard/episode/create` and fill the form and press create. They should see a message episode was created successfully.
#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
#### Screenshots (if appropriate)
#### Questions:

[@unicodeveloper](https://github.com/unicodeveloper)
[@andela-oadebayo](https://github.com/andela-oadebayo)
