### PR TITLE
[Chore #122542671] Extend anchor link to propser and nad twitter images

### DIFF
--- a/resources/views/app/includes/sections/footer.blade.php
+++ b/resources/views/app/includes/sections/footer.blade.php
@@ -7,10 +7,10 @@
             <div class="col l6 s12 m6 center-align">
                 <h5>Hosts</h5>
                     <div class="col s12 m6 center-align waves-effect waves-block waves-light">
-                        <img class="responsive-image circle hosts-image center-align" src="https://goo.gl/O9tD8e" />
-                        <p class="hosts-name center-align">Prosper</p>
-
                         <a href="https://twitter.com/unicodeveloper" target="_blank">
+                            <img class="responsive-image circle hosts-image center-align" src="https://goo.gl/O9tD8e" />
+                            <p class="hosts-name center-align">Prosper</p>
+                        
                             <div class="chip blue-grey-text darken-4">
                                 @unicodeveloper
                                 <i class="fa fa-twitter fa-1x center-align"></i>
@@ -19,10 +19,10 @@
                     </div>
 
                     <div class="col s12 m6 center-align waves-effect waves-block waves-light">
-                        <img class="responsive-image circle hosts-image center-align" src="https://goo.gl/O9tD8e" />
-                        <p class="hosts-name center-align">Prosper</p>
-
                         <a href="https://twitter.com/nadayar" target="_blank">
+                            <img class="responsive-image circle hosts-image center-align" src="https://goo.gl/O9tD8e" />
+                            <p class="hosts-name center-align">Prosper</p>
+
                             <div class="chip blue-grey-text darken-4">
                                 @nad
                                 <i class="fa fa-twitter fa-1x center-align"></i>


### PR DESCRIPTION
#### What does this PR do?

This PR modifies the link to Propser and Nadayar twitter accounts.
#### Description of Task to be completed?

Extend the anchor links to the images for Prosper twitter account, as well as Nadayar's.
#### How should this be manually tested?

On the view to list a collection of episodes, scroll down and click on either Prosper and Nadayar images. This should open the particular twitter account on a new tab or new window.
#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?

The related PT story can be viewed [here](https://www.pivotaltracker.com/story/show/122542671).
#### Screenshots (if appropriate)
#### Questions:

[@unicodeveloper](https://github.com/unicodeveloper)
